### PR TITLE
Volume Component の取得方法を修正

### DIFF
--- a/Assets/Project/Scenes/SampleScene.unity
+++ b/Assets/Project/Scenes/SampleScene.unity
@@ -5133,6 +5133,7 @@ MonoBehaviour:
   _openCloseButton: {fileID: 1290683086}
   _configView: {fileID: 777764971}
   _configButtonText: {fileID: 1764762174}
+  _localProfile: {fileID: 11400000, guid: f463080b270d9bf46b229e0311dedc40, type: 2}
 --- !u!1 &1863164992
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scripts/WavePostEffectController.cs
+++ b/Assets/Project/Scripts/WavePostEffectController.cs
@@ -1,4 +1,5 @@
 using TMPro;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.UI;
@@ -24,11 +25,8 @@ public class WaveEffectController : MonoBehaviour
     {
         get
         {
-            if (!VolumeManager.instance.isInitialized)
-            {
-                VolumeManager.instance.Initialize(null, _localProfile);
-            }
-            return VolumeManager.instance.stack.GetComponent<WaveVolumeComponent>();
+            _localProfile.TryGet(out WaveVolumeComponent component);
+            return component;
         }
     }
 


### PR DESCRIPTION
# What's new?

Volume Component の取得方法を修正。 `VolumeManager` の初期化を介した方法だと、Render Pass 側で処理しているインスタンスと異なるものになってしまうようなので修正。